### PR TITLE
WIP: switch to Webengineview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# build dir
+/build/
+
+# clickable dir
+/.clickable/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libs/pdf.js"]
+	path = libs/pdf.js
+	url = https://github.com/bobo1993324/pdf.js.git
+	branch = UbuntuTouchPdfjsViewer

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# PdfjsViewer - An Ubuntu Touch PDF Viewer
+
+## How to get it
+
+[![OpenStore](https://open-store.io/badges/en_US.png)](https://open-store.io/app/com.ubuntu.developer.bobo1993324.pdfjsviewer)
+
+Or build it yourself following instructions below.
+
+## Building the app
+
+### Dependencies
+Install [clickable](https://github.com/bhdouglass/clickable), which is used to
+build this app.
+
+This app depends on **pdf.js**. You can easily build it by running
+
+    clickable build-libs
+
+This needs to be done only once.
+
+### Installation
+To build and launch the app, simply run
+
+    clickable
+
+To start the app in desktop mode run
+
+    clickable desktop
+
+See [clickable documentation](http://clickable.bhdouglass.com/) for details.
+
+## Contributors
+* Boren Zhang (bobo1993324)
+* Jonatan Hatakeyama Zeidler (jonnius)

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-git clone https://github.com/bobo1993324/pdf.js.git
-cd pdf.js
-git pull origin UbuntuTouchPdfjsViewer
-nodejs make generic
-cd ..

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,7 @@
+{
+  "template": "pure",
+  "ignore": [
+    "build.sh",
+    "package.sh"
+  ]
+}

--- a/clickable.json
+++ b/clickable.json
@@ -3,11 +3,15 @@
   "ignore": [
     "libs"
   ],
+  "install_data": {
+    "${PDF_JS_LIB_INSTALL_DIR}/web": "www",
+    "${PDF_JS_LIB_INSTALL_DIR}/build/pdf*.js": "www/build"
+  },
   "libraries": {
     "pdf.js": {
       "template": "custom",
       "prebuild": "git submodule update --init",
-      "build": "cp -r ${SRC_DIR}/* . && nodejs make generic"
+      "build": "cp -r ${SRC_DIR}/* . && nodejs make generic && rm -rf install && mkdir install && cp -rf web build install/"
     }
   }
 }

--- a/clickable.json
+++ b/clickable.json
@@ -3,5 +3,12 @@
   "ignore": [
     "build.sh",
     "package.sh"
-  ]
+  ],
+  "libraries": {
+    "pdf.js": {
+      "template": "custom",
+      "prebuild": "git submodule update --init",
+      "build": "cp -r ${SRC_DIR}/* . && nodejs make generic"
+    }
+  }
 }

--- a/clickable.json
+++ b/clickable.json
@@ -1,8 +1,7 @@
 {
   "template": "pure",
   "ignore": [
-    "build.sh",
-    "package.sh"
+    "libs"
   ],
   "libraries": {
     "pdf.js": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "com.ubuntu.developer.bobo1993324.pdfjsviewer",
     "description": "A simple PDF viewer built on pdf.js",
-    "framework": "ubuntu-sdk-14.10-qml",
+    "framework": "ubuntu-sdk-16.04",
     "architecture": "all",
     "title": "pdfjsViewer",
     "hooks": {

--- a/package.sh
+++ b/package.sh
@@ -1,8 +1,0 @@
-#! /bin/bash
-mkdir package
-cp qml logo.png manifest.json pdfjsViewer.desktop pdfjsViewer.json pdfjsViewer-contenthub.json www package -rf
-cd package
-click build .
-cp *.click ..
-cd ..
-rm -rf package

--- a/pdfjsViewer.json
+++ b/pdfjsViewer.json
@@ -4,5 +4,5 @@
         "content_exchange",
         "webview"
     ],
-    "policy_version": 1.2
+    "policy_version": 16.04
 }

--- a/qml/ReadPage.qml
+++ b/qml/ReadPage.qml
@@ -1,12 +1,13 @@
 import QtQuick 2.0
 import Ubuntu.Components 1.1
 import Morph.Web 0.1
-// import QtWebEngine 1.7
+import QtWebEngine 1.7
 Page {
     property string fileUrl
     property string webviewUrl: "../www/web/viewer.html?file=" + fileUrl
-    WebView {
+    WebEngineView {
         id: webview
+
         width: parent.width
         height: parent.height
         url: Qt.resolvedUrl(webviewUrl);
@@ -24,5 +25,5 @@ Page {
         httpCacheType: WebEngineProfile.DiskHttpCache; //cache qml content to file
     }
 
-    flickable: webview
+    // flickable: webview
 }

--- a/qml/ReadPage.qml
+++ b/qml/ReadPage.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import Ubuntu.Components 1.1
-import Ubuntu.Web 0.2
+import Morph.Web 0.1
 Page {
     property string fileUrl
     property string webviewUrl: "../www/web/viewer.html?file=" + fileUrl

--- a/qml/ReadPage.qml
+++ b/qml/ReadPage.qml
@@ -1,19 +1,28 @@
 import QtQuick 2.0
 import Ubuntu.Components 1.1
 import Morph.Web 0.1
+// import QtWebEngine 1.7
 Page {
     property string fileUrl
     property string webviewUrl: "../www/web/viewer.html?file=" + fileUrl
     WebView {
         id: webview
         width: parent.width
-		height: parent.height
+        height: parent.height
         url: Qt.resolvedUrl(webviewUrl);
-        preferences.allowUniversalAccessFromFileUrls: true
-        preferences.localStorageEnabled: true
-        filePicker: ContentPickerDialog { }
-        alertDialog: AlertDialog { }
-        popupMenu: PopupMenu { }
+        // preferences.allowUniversalAccessFromFileUrls: true
+        // preferences.localStorageEnabled: true
+        profile: webViewProfile
+        zoomFactor: 1.5
+        // filePicker: ContentPickerDialog { }
+        // alertDialog: AlertDialog { }
+        // popupMenu: PopupMenu { }
     }
+    WebEngineProfile {
+        //for more profile options see https://doc.qt.io/qt-5/qml-qtwebengine-webengineprofile.html
+        id: webViewProfile
+        httpCacheType: WebEngineProfile.DiskHttpCache; //cache qml content to file
+    }
+
     flickable: webview
 }


### PR DESCRIPTION
To reduce the number of commits add changes done by @jonnius with #7 and furthermore add WebEngineview.

With WebEngineView the app does start, if some properties from Oxide are disabled.

Sadly I can not open pdf documents. That always throws javascript errors that I could not overcome.

Errors are:
`js: Uncaught (in promise) TypeError: Cannot read property 'set language' of undefined`

`js: Uncaught TypeError: PDFJS.getDocument is not a function`

`js: Uncaught TypeError: Cannot read property 'numPages' of null` 

In agreement with @jonnius we want to present the work we have done so far, hoping it may help with further development.